### PR TITLE
refactor: update ansilory exports and expose Ansi type from kolory

### DIFF
--- a/.changeset/loud-wombats-hammer.md
+++ b/.changeset/loud-wombats-hammer.md
@@ -1,0 +1,5 @@
+---
+'ansilory': major
+---
+
+Change default export to `ansi` and keep `o` as deprecated named export

--- a/.changeset/some-rivers-speak.md
+++ b/.changeset/some-rivers-speak.md
@@ -1,0 +1,5 @@
+---
+'kolory': patch
+---
+
+Export the `Ansi` type definition

--- a/packages/ansilory/src/index.ts
+++ b/packages/ansilory/src/index.ts
@@ -1,6 +1,10 @@
-import { ansi } from 'kolory';
+import { ansi as ansiCodes, Ansi } from 'kolory';
 
-const o = ansi;
+/**
+ * @deprecated Use `ansi` instead
+ */
+export const o: Ansi = ansiCodes;
 
-export { o };
-export default o;
+export const ansi: Ansi = ansiCodes;
+
+export default ansi;

--- a/packages/kolory/src/index.ts
+++ b/packages/kolory/src/index.ts
@@ -14,7 +14,7 @@ type Formats = {
   };
 };
 
-type Ansi = {
+export type Ansi = {
   [K in AnsiKey]: Ansi;
 } & {
   (text: string): void;


### PR DESCRIPTION
- Updated ansilory default export to `ansi` for clearer usage.  
- Marked the previous named export `o` as deprecated to guide users towards `ansi`.  
- Exported the `Ansi` type from kolory to enable external type usage.  

This improves clarity in imports and provides stronger TypeScript support for users leveraging ansilory and kolory together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ansilory introduces a new named export ansi and sets it as the default export.
  - kolory now publicly exports the Ansi type.

- Refactor
  - Standardized exports around ansi; the previous alias o remains available but is deprecated.

- Chores
  - Major version bump for ansilory.
  - Added changesets documenting the API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->