### PR TITLE
fix: sylog export & license link

### DIFF
--- a/.changeset/chatty-toys-teach.md
+++ b/.changeset/chatty-toys-teach.md
@@ -1,0 +1,6 @@
+---
+'@tenedev/git-log': patch
+'kolory': patch
+---
+
+Fixed README license link

--- a/.changeset/solid-otters-speak.md
+++ b/.changeset/solid-otters-speak.md
@@ -1,0 +1,5 @@
+---
+'sylog': patch
+---
+
+Added default export for `sylog` instance

--- a/packages/git-log/README.md
+++ b/packages/git-log/README.md
@@ -163,4 +163,4 @@ a1b2c3d;"Jane Doe";"2024-08-10T12:00:00+00:00";"feat: add new API endpoint"
 
 ## License
 
-Released under the [Apache License 2.0](./LICENSE).
+Released under the [Apache License 2.0](../../LICENSE).

--- a/packages/kolory/README.md
+++ b/packages/kolory/README.md
@@ -192,4 +192,4 @@ We welcome contributions to make Kolory even better! To contribute:
 
 ## License
 
-Kolory is licensed under the [Apache License 2.0](./LICENSE).
+Kolory is licensed under the [Apache License 2.0](../../LICENSE).

--- a/packages/sylog/README.md
+++ b/packages/sylog/README.md
@@ -90,4 +90,4 @@ sylog.info('Item 1', 'Item 2', { key: 'value' }, { sep: ' | ', end: '\n\n' });
 
 ## License
 
-Released under the [Apache License 2.0](./LICENSE).
+Released under the [Apache License 2.0](../../LICENSE).

--- a/packages/sylog/index.ts
+++ b/packages/sylog/index.ts
@@ -192,3 +192,4 @@ export class Sylog {
  * ```
  */
 export const sylog = new Sylog();
+export default sylog;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added default import support for the sylog instance, while retaining existing named import compatibility.

- Documentation
  - Fixed incorrect LICENSE links in package READMEs to point to the root license file.

- Chores
  - Added changeset entries to publish patch releases for sylog, git-log, and kolory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->