### PR TITLE
feat: add dryrun log level and update debug color

### DIFF
--- a/.changeset/itchy-brooms-hide.md
+++ b/.changeset/itchy-brooms-hide.md
@@ -1,0 +1,14 @@
+---
+'sylog': minor
+---
+
+**Added**
+
+- Introduced a new `dryrun` log level to indicate simulated operations.
+- Added `sylog.dryrun()` helper method.
+- Added default `DRYRUN` label and magenta styling for dry-run messages.
+
+**Changed**
+
+- Updated the `debug` log level color from cyan to gray for improved readability and reduced visual noise.
+- Extended internal `Levels` type and color/label maps to support the new `dryrun` log level and updated `debug` color.

--- a/packages/sylog/index.ts
+++ b/packages/sylog/index.ts
@@ -46,7 +46,8 @@ export class Sylog {
     warn: (txt) => ansi.yellow.bold.apply(txt),
     error: (txt) => ansi.red.bold.apply(txt),
     success: (txt) => ansi.green.bold.apply(txt),
-    debug: (txt) => ansi.cyan.bold.apply(txt),
+    debug: (txt) => ansi.gray.bold.apply(txt),
+    dryrun: (txt) => ansi.magenta.bold.apply(txt),
   };
 
   /** Default {@link SylogOpts} options */
@@ -62,6 +63,7 @@ export class Sylog {
       error: 'ERROR',
       success: 'SUCCESS',
       debug: 'DEBUG',
+      dryrun: 'DRYRUN',
     },
   };
 
@@ -260,6 +262,18 @@ export class Sylog {
   debug(...args: LogArgs) {
     if (!this.opts.debug) return;
     this.write(process.stdout, 'debug', ...args);
+  }
+
+  /**
+   * Logs a dry-run message
+   *
+   * @example
+   * ```ts
+   * sylog.dryrun('Dry run mode enabled');
+   * ```
+   */
+  dryrun(...args: LogArgs) {
+    this.write(process.stdout, 'dryrun', ...args);
   }
 }
 

--- a/packages/sylog/types.ts
+++ b/packages/sylog/types.ts
@@ -1,5 +1,12 @@
 /** Log levels */
-export type Levels = 'log' | 'info' | 'warn' | 'error' | 'success' | 'debug';
+export type Levels =
+  | 'log'
+  | 'info'
+  | 'warn'
+  | 'error'
+  | 'success'
+  | 'debug'
+  | 'dryrun';
 
 /**
  * - Arguments passed to log methods.


### PR DESCRIPTION
Added a new `dryrun` log level with default `DRYRUN` label and magenta styling, plus a new `sylog.dryrun()` method. Updated the debug log level color from cyan to gray for better readability. Extended the Levels type, default options, and color mappings accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run logging level for simulated operations, labeled "DRYRUN" in magenta.

* **Style**
  * Updated debug log color from cyan to gray.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->